### PR TITLE
[Fix] fetcher 클래스에서 클라이언트, 서버 로직 둘 다 수용할 수 있도록 수정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           run_install: false
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run build
         run: pnpm run build

--- a/apps/admin/apis/auth/dashboardApi.ts
+++ b/apps/admin/apis/auth/dashboardApi.ts
@@ -1,21 +1,14 @@
 import { fetcher } from "@wow-class/utils";
 import { apiPath } from "constants/apiPath";
 import { tags } from "constants/tags";
-import { cookies } from "next/headers";
-import type { DashboardApiResponseDto } from "types/dto/auth";
+import type { DashboardApiResponseDto } from "types/dtos/auth";
 
 export const dashboardApi = {
   getDashboardInfo: async () => {
-    const cookieStore = cookies();
-    const accessToken = cookieStore.get("accessToken")?.value;
-
     const response = await fetcher.get<DashboardApiResponseDto>(
       apiPath.dashboard,
       {
         next: { tags: [tags.dashboard] },
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
       }
     );
 

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -25,11 +25,8 @@ const middleware = async (req: NextRequest) => {
 
     return NextResponse.redirect(new URL("/auth", url));
   }
-  const response = NextResponse.next();
 
-  response.headers.set("Authorization", `Bearer ${accessToken}`);
-
-  return response;
+  return NextResponse.next();
 };
 
 export default middleware;

--- a/apps/client/apis/dashboardApi.ts
+++ b/apps/client/apis/dashboardApi.ts
@@ -1,22 +1,14 @@
 import { fetcher } from "@wow-class/utils";
 import { apiPath } from "constants/apiPath";
 import { tags } from "constants/tags";
-import { cookies } from "next/headers";
 import type { DashboardApiResponseDto } from "types/dtos/auth";
 
 export const dashboardApi = {
   getDashboardInfo: async () => {
-    const cookieStore = cookies();
-    const accessToken = cookieStore.get("accessToken")?.value;
-
-    // NOTE: middleware에서 호출하기 위해서 별도로 헤더 주입
     const response = await fetcher.get<DashboardApiResponseDto>(
       apiPath.dashboard,
       {
         next: { tags: [tags.dashboard] },
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
       }
     );
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "clsx": "^2.1.1",
     "wowds-icons": "^0.1.3",
     "wowds-tokens": "^0.1.1",
-    "wowds-ui": "^0.1.8",
-    "wowds-icons": "^0.1.2"
+    "wowds-ui": "^0.1.8"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,11 +10,14 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@wow-class/eslint-config": "workspace:*",
     "@wow-class/typescript-config": "workspace:*",
     "jest": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
-    "ts-jest": "^29.2.4",
-    "@wow-class/eslint-config": "workspace:*",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "ts-jest": "^29.2.4"
+  },
+  "dependencies": {
+    "next": "^14.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,10 @@ importers:
         version: 5.4.5
 
   packages/utils:
+    dependencies:
+      next:
+        specifier: ^14.2.5
+        version: 14.2.5(@babel/core@7.25.2)(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@types/jest':
         specifier: ^29.5.12


### PR DESCRIPTION
## 🎉 변경 사항
fetcher 클래스에서 클라이언트, 서버 로직 둘 다 수용할 수 있도록 수정했습니다.

이전에 [유진님이 언급](https://github.com/GDSC-Hongik/wow-class/pull/20#discussion_r1715592663)하신 것처럼 fetcher 클래스 내부에 next/headers의 cookies 관련 import문이 최상단에 포함되면 클라이언트 컴포넌트쪽에서도 해당 import문을 읽어오기 때문에 클라이언트 컴포넌트 쪽에서 에러가 발생했습니다.

해당 에러는 [You're importing a component that needs next/headers.](https://github.com/vercel/next.js/issues/49757) 라는 내용이었는데, app 라우터 외부에서 next/headers 관련 로직을 사용하게 되면 발생하는 에러라고 합니다.
저희는 모노레포 구조 + 클라이언트와 서버에서 공통으로 사용해야 하는 코드이기 때문에 별도 패키지로 분리할 수밖에 없습니다.

그래서 해당 이슈에 기재된 것처럼 서버 환경에서만 동적 import문을 사용해서 next/headers의 cookies를 불러오도록 했고, 클라이언트 환경에서는 api 요청 시 인증 정보가 포함되어야 하기 때문에 credentials: include 로직을 추가해주었습니다.
현재 서버분들께서 심어주시는 쿠키가 httpOnly로 설정되어 있어 클라이언트에서는 읽을 수 없기 때문에 해당 옵션으로 해결했습니다.

세은님이 올려주신 api 요청 PR에서 클라이언트 측, 서버 측에서 요청이 잘 되는지 확인 완료하고 올립니다...
@hamo-o @eugene028 님께서는 프록시 사용해서 확인이 가능하니 문제 없이 요청되는지 확인 부탁드립니다.

## 🚩 관련 이슈
- #32 

## 🙏 여기는 꼭 봐주세요!
