### PR TITLE
[Feature]: 개설된 스터디 보기 api 연동 

### DIFF
--- a/apps/admin/apis/study/createStudyApi.ts
+++ b/apps/admin/apis/study/createStudyApi.ts
@@ -1,0 +1,18 @@
+import { fetcher } from "@wow-class/utils";
+import { apiPath } from "constants/apiPath";
+import { tags } from "constants/tags";
+import type { StudyListApiResponseDto } from "types/dtos/studyList";
+
+export const createStudyApi = {
+  getStudyList: async () => {
+    const response = await fetcher.get<StudyListApiResponseDto[]>(
+      apiPath.studyList,
+      {
+        next: { tags: [tags.studyList] },
+        cache: "force-cache",
+      }
+    );
+
+    return response.data;
+  },
+};

--- a/apps/admin/app/studies/_components/StudyList.tsx
+++ b/apps/admin/app/studies/_components/StudyList.tsx
@@ -1,0 +1,122 @@
+import { css } from "@styled-system/css";
+import { Flex } from "@styled-system/jsx";
+import { Table, Text } from "@wow-class/ui";
+import { createStudyApi } from "apis/study/createStudyApi";
+import Image from "next/image";
+import Link from "next/link";
+import type { ComponentProps } from "react";
+import type { StudyType } from "types/entities/study";
+import isAdmin from "utils/isAdmin";
+import Button from "wowds-ui/Button";
+import Tag from "wowds-ui/Tag";
+
+const StudyList = async () => {
+  const adminStatus = await isAdmin();
+
+  const studyList = await createStudyApi.getStudyList();
+
+  if (studyList?.length === 0) {
+    return (
+      <Flex
+        alignItems="center"
+        direction="column"
+        gap="xl"
+        height="100%"
+        justifyContent="center"
+        width="100%"
+      >
+        <Image
+          alt="study-empty"
+          height={186}
+          src="/images/empty.svg"
+          width={140}
+        />
+        <Text color="sub" typo="h2">
+          개설된 스터디가 없어요
+        </Text>
+      </Flex>
+    );
+  }
+  return (
+    <section aria-label="study-list" className={SectionStyle}>
+      {studyList?.map(
+        ({ studyId, title, studyType, notionLink, mentorName }, index) => {
+          return (
+            <Table key={`${index}-${studyId}`}>
+              <Table.Left>
+                <Flex alignItems="center" gap="31px">
+                  <Text typo="body1">2024-1</Text>
+                  <Flex alignItems="center" gap="xs">
+                    <Text typo="h3">{title}</Text>
+                    <Tag color={studyTypeColorMap[studyType]} variant="solid1">
+                      {studyType}
+                    </Tag>
+                  </Flex>
+                </Flex>
+              </Table.Left>
+
+              <Table.Right>
+                <Flex alignItems="center" gap="64px">
+                  <Text typo="body1">{mentorName} 멘토</Text>
+                  <Link
+                    href={notionLink}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      color: "sub",
+                      gap: "8px",
+                    }}
+                  >
+                    <Image
+                      alt="study-link"
+                      height={24}
+                      src="/images/link.svg"
+                      width={24}
+                    />
+                    <Text
+                      color="sub"
+                      style={{ textDecoration: "underline" }}
+                      typo="label1"
+                    >
+                      스터디 소개 페이지
+                    </Text>
+                  </Link>
+                  <Flex alignItems="center" gap="sm">
+                    {adminStatus && (
+                      <Button size="sm" variant="outline">
+                        스터디 삭제
+                      </Button>
+                    )}
+                    <Link href={`/studies/detail-info/${studyId}`}>
+                      <Button size="sm" variant="solid">
+                        상세 정보 입력
+                      </Button>
+                    </Link>
+                  </Flex>
+                </Flex>
+              </Table.Right>
+            </Table>
+          );
+        }
+      )}
+    </section>
+  );
+};
+
+const studyTypeColorMap: Record<
+  StudyType,
+  ComponentProps<typeof Tag>["color"]
+> = {
+  "과제 스터디": "green",
+  "온라인 세션": "blue",
+  "오프라인 세션": "yellow",
+};
+
+export default StudyList;
+
+const SectionStyle = css({
+  width: "100%",
+  height: "100%",
+  overflow: "scroll",
+  scrollbarWidth: "none",
+});

--- a/apps/admin/app/studies/detail-info/[studyId]/page.tsx
+++ b/apps/admin/app/studies/detail-info/[studyId]/page.tsx
@@ -1,0 +1,5 @@
+const CreateStudyDetailInfoPage = () => {
+  return <>스터디 상세 작성</>;
+};
+
+export default CreateStudyDetailInfoPage;

--- a/apps/admin/app/studies/layout.tsx
+++ b/apps/admin/app/studies/layout.tsx
@@ -8,8 +8,8 @@ const StudiesLayout = ({
   return (
     <>
       <Navbar />
-      <styled.div padding="54px 101px" width="100%">
-        <Flex direction="column" gap="sm" width="100%">
+      <styled.div height="100vh" padding="54px 101px" width="100%">
+        <Flex direction="column" gap="sm" height="100%" width="100%">
           {children}
         </Flex>
       </styled.div>

--- a/apps/admin/app/studies/page.tsx
+++ b/apps/admin/app/studies/page.tsx
@@ -1,6 +1,7 @@
 import { css } from "@styled-system/css";
 import { Flex } from "@styled-system/jsx";
 
+import StudyList from "./_components/StudyList";
 import CreateStudyButton from "./create-study/_components/CreateStudyButton";
 
 const StudiesPage = () => {
@@ -10,6 +11,7 @@ const StudiesPage = () => {
         <p className={css({ textStyle: "h1" })}>개설된 스터디</p>
       </Flex>
       <CreateStudyButton />
+      <StudyList />
     </>
   );
 };

--- a/apps/admin/constants/apiPath.ts
+++ b/apps/admin/constants/apiPath.ts
@@ -1,3 +1,4 @@
 export const enum apiPath {
   dashboard = "/onboarding/members/me/dashboard",
+  studyList = "/admin/studies",
 }

--- a/apps/admin/constants/tags.ts
+++ b/apps/admin/constants/tags.ts
@@ -1,3 +1,4 @@
 export const enum tags {
   dashboard = "dashboard",
+  studyList = "studyList",
 }

--- a/apps/admin/public/images/empty.svg
+++ b/apps/admin/public/images/empty.svg
@@ -1,0 +1,23 @@
+<svg width="187" height="140" viewBox="0 0 187 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" width="171.637" height="110.694" rx="10.7722" fill="#EFEFEF"/>
+<ellipse cx="14.5039" cy="13.2976" rx="4.66795" ry="4.67213" fill="#7F7F7F"/>
+<ellipse cx="27.4305" cy="13.2976" rx="4.66795" ry="4.67213" fill="#BABABA"/>
+<ellipse cx="40.3572" cy="13.2976" rx="4.66795" ry="4.67213" fill="#939393"/>
+<path d="M91.8765 60.5659L139.102 36.9318L186.328 60.5659L139.102 81.9129L91.8765 60.5659Z" fill="url(#paint0_linear_895_6228)"/>
+<path d="M91.7047 60.394L139.102 81.5983V140L91.7047 117.358V60.394Z" fill="url(#paint1_linear_895_6228)"/>
+<path d="M186.5 60.394L139.102 81.5983V140L186.5 117.358V60.394Z" fill="url(#paint2_linear_895_6228)"/>
+<defs>
+<linearGradient id="paint0_linear_895_6228" x1="115.489" y1="36.9318" x2="162.758" y2="84.1578" gradientUnits="userSpaceOnUse">
+<stop stop-color="#D8D8D8"/>
+<stop offset="1" stop-color="#A6A6A6"/>
+</linearGradient>
+<linearGradient id="paint1_linear_895_6228" x1="115.404" y1="60.394" x2="115.404" y2="140" gradientUnits="userSpaceOnUse">
+<stop stop-color="#777777"/>
+<stop offset="1" stop-color="#9E9E9E"/>
+</linearGradient>
+<linearGradient id="paint2_linear_895_6228" x1="162.801" y1="60.394" x2="162.801" y2="140" gradientUnits="userSpaceOnUse">
+<stop stop-color="#D8D8D8"/>
+<stop offset="1" stop-color="#A6A6A6"/>
+</linearGradient>
+</defs>
+</svg>

--- a/apps/admin/public/images/link.svg
+++ b/apps/admin/public/images/link.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.40033 16H2.75196V8H9.40033M14.6003 16H21.25V8H14.6003" stroke="#6B6B6B" stroke-width="1.4"/>
+<path d="M17 12L7 12" stroke="#6B6B6B" stroke-width="1.4"/>
+</svg>

--- a/apps/admin/types/dtos/studyList.ts
+++ b/apps/admin/types/dtos/studyList.ts
@@ -1,0 +1,26 @@
+import type { StudyType } from "types/entities/study";
+
+export interface StudyListApiResponseDto {
+  studyId: number;
+  title: string;
+  studyType: StudyType;
+  notionLink: string;
+  introduction: string;
+  mentorName: string;
+  dayOfWeek:
+    | "MONDAY"
+    | "TUESDAY"
+    | "WEDNESDAY"
+    | "THURSDAY"
+    | "FRIDAY"
+    | "SATURDAY"
+    | "SUNDAY";
+  startTime: {
+    hour: number;
+    minute: number;
+    second: number;
+    nano: number;
+  };
+  totalWeek: number;
+  openingDate: string;
+}

--- a/apps/admin/types/entities/study.ts
+++ b/apps/admin/types/entities/study.ts
@@ -1,0 +1,1 @@
+export type StudyType = "과제 스터디" | "온라인 세션" | "오프라인 세션";


### PR DESCRIPTION
## 🎉 변경 사항
어드민 뷰의 개설된 스터디 보기 화면에 대한 UI를 구성하고, api를 연결했어요.
<img width="686" alt="스크린샷 2024-08-20 오후 4 31 55" src="https://github.com/user-attachments/assets/f6a6fe7f-6e70-419f-9534-d0da10158053">

## 여기는 꼭 봐주세요! 🙏
현재 개설된 스터디에 대한 get 정보를 내려주고 있는 api에서 **학기, 년도 정보**를 내려주고 있지 않아 임의로 2024-1로 하드코딩을 해 둔 상황입니다. 백엔드 개발자분들께 요청해둔 상황입니당. 이 점 참고부탁드립니다
관련 스레드 : https://gdschongik.slack.com/archives/C06Q93M2U81/p1724139303621999