### PR TITLE
[Fix] 프로덕션/개발 환경 구분 환경 변수 VERCEL_ENV로 변경

### DIFF
--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -19,7 +19,7 @@ const middleware = async (req: NextRequest) => {
 
   if (studyRole === "STUDENT" && manageRole === "NONE") {
     const url =
-      process.env.NODE_ENV === "production"
+      process.env.VERCEL_ENV === "production"
         ? process.env.CLIENT_PROD_URL
         : process.env.CLIENT_DEV_URL;
 

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -19,7 +19,7 @@ const middleware = async (req: NextRequest) => {
 
   if (studyRole === "STUDENT" && manageRole === "NONE") {
     const url =
-      process.env.VERCEL_ENV === "production"
+      process.env.NEXT_PUBLIC_VERCEL_ENV === "production"
         ? process.env.CLIENT_PROD_URL
         : process.env.CLIENT_DEV_URL;
 

--- a/apps/client/constants/environment.ts
+++ b/apps/client/constants/environment.ts
@@ -1,4 +1,4 @@
 export const baseUrl =
-  process.env.VERCEL_ENV === "production"
+  process.env.NEXT_PUBLIC_VERCEL_ENV === "production"
     ? process.env.NEXT_PUBLIC_PROD_BASE_URL
     : process.env.NEXT_PUBLIC_DEV_BASE_URL;

--- a/apps/client/constants/environment.ts
+++ b/apps/client/constants/environment.ts
@@ -1,4 +1,4 @@
 export const baseUrl =
-  process.env.NODE_ENV === "production"
+  process.env.VERCEL_ENV === "production"
     ? process.env.NEXT_PUBLIC_PROD_BASE_URL
     : process.env.NEXT_PUBLIC_DEV_BASE_URL;

--- a/packages/utils/src/fetcher/index.ts
+++ b/packages/utils/src/fetcher/index.ts
@@ -166,7 +166,7 @@ const isClient = typeof window !== "undefined";
 
 const fetcher = new Fetcher({
   baseUrl:
-    process.env.NODE_ENV === "production"
+    process.env.VERCEL_ENV === "production"
       ? process.env.NEXT_PUBLIC_PROD_BASE_URL
       : process.env.NEXT_PUBLIC_DEV_BASE_URL,
   defaultHeaders: { "Content-Type": "application/json" },

--- a/packages/utils/src/fetcher/index.ts
+++ b/packages/utils/src/fetcher/index.ts
@@ -166,7 +166,7 @@ const isClient = typeof window !== "undefined";
 
 const fetcher = new Fetcher({
   baseUrl:
-    process.env.VERCEL_ENV === "production"
+    process.env.NEXT_PUBLIC_VERCEL_ENV === "production"
       ? process.env.NEXT_PUBLIC_PROD_BASE_URL
       : process.env.NEXT_PUBLIC_DEV_BASE_URL,
   defaultHeaders: { "Content-Type": "application/json" },


### PR DESCRIPTION
<!-- 제목: [Feature] PR내용
ex) [Feature] 프로젝트 초기 세팅 -->

## 🎉 변경 사항

vercel 배포했을 때 preview 환경에서도 production api url로 요청이 나가서 프로덕션/개발 환경 구분 환경 변수 VERCEL_ENV로 변경했습니다.
https://stackoverflow.com/questions/76729798/how-to-manage-process-env-node-env-on-vercel

## 🚩 관련 이슈
- #66 

## 🙏 여기는 꼭 봐주세요!
