### PR TITLE
[Design] nav-item 경로 이슈 때문에 색 적용 안 되는 문제 해결

### DIFF
--- a/packages/ui/src/components/NavItem/index.tsx
+++ b/packages/ui/src/components/NavItem/index.tsx
@@ -46,6 +46,11 @@ const NavItem = ({ href, imageUrl, alt, name, items }: NavItemProps) => {
     }
   };
 
+  const navItemType =
+    (!segment[1] && `${segment[0]}` === href) || `/${segment[0]}` === href
+      ? "active"
+      : "inactive";
+
   return (
     <styled.div listStyle="none" role="presentation">
       <Link
@@ -55,7 +60,7 @@ const NavItem = ({ href, imageUrl, alt, name, items }: NavItemProps) => {
         href={`${href}`}
         tabIndex={0}
         className={navItemStyle({
-          type: !segment[1] && `${segment[0]}` === href ? "active" : "inactive",
+          type: navItemType,
         })}
         onClick={handleClickNavItem}
       >


### PR DESCRIPTION
<!-- 제목: [Feature] PR내용
ex) [Feature] 프로젝트 초기 세팅 -->

## 🎉 변경 사항
nav-item 경로 이슈 때문에 색 적용 안 되는 문제 해결했습니다.
아마 어드민 쪽이랑 경로 설정이 달라서 그런 거 같아요
그냥 절대 경로, 상대 경로 둘 다 되도록 변경해뒀습니다!

## 🚩 관련 이슈

## 🙏 여기는 꼭 봐주세요!
