### PR TITLE
[Fix] 과제 종료 날짜 현재일 이후로 설정 가능하도록 수정

### DIFF
--- a/apps/admin/app/studies/[studyId]/_components/assignment/AssignmentList.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/assignment/AssignmentList.tsx
@@ -7,8 +7,6 @@ const AssignmentList = async ({ studyId }: { studyId: string }) => {
   const assignmentList = await studyApi.getAssignmentList(
     parseInt(studyId, 10)
   );
-  const study = await studyApi.getStudyBasicInfo(+studyId);
-  const studyStartDate = study?.period?.startDate;
 
   return (
     <section aria-label="assignment-list">
@@ -19,7 +17,6 @@ const AssignmentList = async ({ studyId }: { studyId: string }) => {
           <AssignmentListItem
             assignment={assignment}
             key={`studyDetailId-${index}`}
-            studyStartDate={studyStartDate}
           />
         );
       })}

--- a/apps/admin/app/studies/[studyId]/_components/assignment/AssignmentListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/assignment/AssignmentListItem.tsx
@@ -9,12 +9,17 @@ import AssignmentButtons from "./AssignmentButtons";
 
 const AssignmentListItem = ({
   assignment,
-  studyStartDate,
 }: {
   assignment: AssignmentApiResponseDto;
-  studyStartDate?: string;
 }) => {
-  const { studyDetailId, title, deadline, week, assignmentStatus } = assignment;
+  const {
+    studyDetailId,
+    title,
+    deadline,
+    week,
+    assignmentStatus,
+    studyDetailStartDate,
+  } = assignment;
 
   const formatDateToEndString = (date: string | null) => {
     if (!date) return "-";
@@ -23,8 +28,7 @@ const AssignmentListItem = ({
     return `종료 : ${year}년 ${month}월 ${day}일 ${padWithZero(hours)}:${padWithZero(minutes)}`;
   };
 
-  const thisWeekAssignment =
-    studyStartDate && getIsCurrentWeek(studyStartDate, week);
+  const thisWeekAssignment = getIsCurrentWeek(studyDetailStartDate);
   const studyDeadline = formatDateToEndString(deadline);
 
   return (

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -26,7 +26,7 @@ const CurriculumListItem = ({
   const { month: endMonth, day: endDay } = parseISODate(endDate);
 
   const curriculumTimeLine = `${padWithZero(startMonth)}.${padWithZero(startDay)} - ${padWithZero(endMonth)}.${padWithZero(endDay)}`;
-  const thisWeekAssignment = getIsCurrentWeek(startDate, week);
+  const thisWeekAssignment = getIsCurrentWeek(startDate);
 
   return (
     <Table>

--- a/apps/admin/app/studies/assignments/[studyDetailId]/_components/AssignmentForm.tsx
+++ b/apps/admin/app/studies/assignments/[studyDetailId]/_components/AssignmentForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Flex } from "@styled-system/jsx";
-import { formatDateToISOString, formatStringToDate } from "@wow-class/utils";
+import { formatDateToISOString } from "@wow-class/utils";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import type {
@@ -20,12 +20,12 @@ const AssignmentForm = ({
   assignment: AssignmentApiResponseDto;
 }) => {
   const { control, setValue } = useFormContext<AssignmentApiRequestDto>();
-  const { title, descriptionLink, deadline } = assignment;
+  const { title, descriptionLink, deadline, studyDetailStartDate } = assignment;
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(
     deadline ? new Date(deadline) : undefined
   );
 
-  const startDate = findStartDate();
+  const startDate = findStartDate(studyDetailStartDate);
 
   return (
     <Flex direction="column" gap="2.25rem">
@@ -75,7 +75,7 @@ const findStartDate = (curriculumStartString?: string) => {
   );
   if (!curriculumStartString) return tomorrow;
 
-  const curriculumStartDate = formatStringToDate(curriculumStartString);
+  const curriculumStartDate = new Date(curriculumStartString);
 
   const curriculumStartTime = curriculumStartDate.getTime();
   const tomorrowTime = tomorrow.getTime();

--- a/apps/admin/app/studies/assignments/[studyDetailId]/_components/AssignmentForm.tsx
+++ b/apps/admin/app/studies/assignments/[studyDetailId]/_components/AssignmentForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Flex } from "@styled-system/jsx";
-import { formatDateToISOString } from "@wow-class/utils";
+import { formatDateToISOString, formatStringToDate } from "@wow-class/utils";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import type {
@@ -24,6 +24,8 @@ const AssignmentForm = ({
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(
     deadline ? new Date(deadline) : undefined
   );
+
+  const startDate = findStartDate();
 
   return (
     <Flex direction="column" gap="2.25rem">
@@ -55,14 +57,31 @@ const AssignmentForm = ({
         }}
       >
         <SingleDatePicker
+          disabled={startDate && { before: startDate }}
           label="종료 날짜"
-          // TODO: 해당 과제 주차만 선택할 수 있도록?
-          // disabled={{}}
         />
         <TimePicker label="종료 시간" />
       </PickerGroup>
     </Flex>
   );
+};
+
+const findStartDate = (curriculumStartString?: string) => {
+  const today = new Date();
+  const tomorrow = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() + 1
+  );
+  if (!curriculumStartString) return tomorrow;
+
+  const curriculumStartDate = formatStringToDate(curriculumStartString);
+
+  const curriculumStartTime = curriculumStartDate.getTime();
+  const tomorrowTime = tomorrow.getTime();
+
+  if (curriculumStartTime > tomorrowTime) return curriculumStartDate;
+  return tomorrow;
 };
 
 export default AssignmentForm;

--- a/apps/admin/app/studies/assignments/[studyDetailId]/page.tsx
+++ b/apps/admin/app/studies/assignments/[studyDetailId]/page.tsx
@@ -17,7 +17,6 @@ const AssignmentsPage = async ({
   const assignment = await studyApi.getAssignment(+studyDetailId);
   if (!assignment) return null;
   const { week, title, studyTitle, descriptionLink, deadline } = assignment;
-  console.log(assignment);
 
   if (!deadline) return null;
   const { year, month, day, hours, minutes } = parseISODate(deadline);

--- a/apps/admin/types/dtos/assignmentList.ts
+++ b/apps/admin/types/dtos/assignmentList.ts
@@ -8,6 +8,7 @@ export interface AssignmentApiResponseDto {
   week: number;
   descriptionLink: string | null;
   assignmentStatus: StudyAssignmentStatusType;
+  studyDetailStartDate: string;
 }
 
 export interface AssignmentApiRequestDto {

--- a/apps/admin/utils/getIsCurrentWeek.ts
+++ b/apps/admin/utils/getIsCurrentWeek.ts
@@ -1,12 +1,12 @@
-const getIsCurrentWeek = (dateString: string, week: number): boolean => {
+const getIsCurrentWeek = (dateString: string): boolean => {
   const startDate = new Date(dateString);
   const today = new Date();
 
   const diffInTime = today.getTime() - startDate.getTime();
   const diffInDays = Math.floor(diffInTime / (1000 * 60 * 60 * 24));
-  const weekNumber = Math.ceil((diffInDays + 1) / 7);
+  console.log(diffInDays);
 
-  return weekNumber === week;
+  return 0 <= diffInDays && diffInDays < 7;
 };
 
 export default getIsCurrentWeek;

--- a/apps/admin/utils/getIsCurrentWeek.ts
+++ b/apps/admin/utils/getIsCurrentWeek.ts
@@ -4,7 +4,6 @@ const getIsCurrentWeek = (dateString: string): boolean => {
 
   const diffInTime = today.getTime() - startDate.getTime();
   const diffInDays = Math.floor(diffInTime / (1000 * 60 * 60 * 24));
-  console.log(diffInDays);
 
   return 0 <= diffInDays && diffInDays < 7;
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "clsx": "^2.1.1",
     "wowds-icons": "^0.1.4",
     "wowds-tokens": "^0.1.1",
-    "wowds-ui": "^0.1.15"
+    "wowds-ui": "^0.1.16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.3
       wowds-ui:
-        specifier: ^0.1.15
-        version: 0.1.15(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^0.1.16
+        version: 0.1.16(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@pandacss/dev':
         specifier: ^0.44.0
@@ -13739,8 +13739,8 @@ packages:
     resolution: {integrity: sha512-Pej6MuUec/i6A04gWELi4bb/T2I8gf/57L9rX8G7ElVeMc7/03ELoM0nBFWKybtpYExXhhlQPp0Lg7iqATpy6Q==}
     dev: false
 
-  /wowds-ui@0.1.15(next@14.2.5)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-4RVyZttz9KI2LveNu/lNjIiDixackqH42xKh8tqdsnvXZfrcYdUBgt1u4tm3eOAX4LivYKAlPaMB6chZynGYIw==}
+  /wowds-ui@0.1.16(next@14.2.5)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-pJM0k67+j1mNjOtxuOWLfSaTs3PKzKKCoUDZ3gUGE8yfwpZr5QgE0vDd8hgGiZweB35+q/5QWO4NPAJKQkPIug==}
     peerDependencies:
       next: ^14.1.1
       react: ^18.2.0


### PR DESCRIPTION
## 🎉 변경 사항
과제 종료 날짜 설정 캘린더에서 현재일 포함 이전 날짜를 비활성화시킵니다.

## 🚩 관련 이슈
- #117 

## 🙏 여기는 꼭 봐주세요!
- 커리큘럼 시작일을 가져올 수 없어서, 백엔드 분들께 해당 필드 [문의드렸습니다](https://gdschongik.slack.com/archives/C06Q93M2U81/p1725040860831479)
- 우선 현재일 체크라도 하면 좋을 것 같아서 먼저 PR 올립니다.
- 비활성화 처리 + 드롭다운 QA 반영을 위해 와디 버전업했습니다.