### PR TITLE
[Fix] 스터디 목록 조회를 멘토용 조회 API로 수정해요.

### DIFF
--- a/apps/admin/apis/auth/dashboardApi.ts
+++ b/apps/admin/apis/auth/dashboardApi.ts
@@ -2,7 +2,6 @@ import { fetcher } from "@wow-class/utils";
 import { apiPath, mentorApiPath } from "constants/apiPath";
 import { tags } from "constants/tags";
 import type { DashboardApiResponseDto } from "types/dtos/auth";
-import type { MyStudyListApiResponseDto } from "types/dtos/studyList";
 
 export const dashboardApi = {
   getDashboardInfo: async () => {

--- a/apps/admin/apis/auth/dashboardApi.ts
+++ b/apps/admin/apis/auth/dashboardApi.ts
@@ -19,14 +19,4 @@ export const dashboardApi = {
 
     return { studyRole, manageRole };
   },
-  getMyStudyList: async () => {
-    const response = await fetcher.get<MyStudyListApiResponseDto[]>(
-      mentorApiPath.studyList,
-      {
-        next: { tags: [tags.dashboard] },
-        cache: "force-cache",
-      }
-    );
-    return response.data;
-  },
 };

--- a/apps/admin/apis/auth/dashboardApi.ts
+++ b/apps/admin/apis/auth/dashboardApi.ts
@@ -1,5 +1,5 @@
 import { fetcher } from "@wow-class/utils";
-import { apiPath, mentorApiPath } from "constants/apiPath";
+import { apiPath } from "constants/apiPath";
 import { tags } from "constants/tags";
 import type { DashboardApiResponseDto } from "types/dtos/auth";
 

--- a/apps/admin/apis/study/studyApi.ts
+++ b/apps/admin/apis/study/studyApi.ts
@@ -24,6 +24,16 @@ export const studyApi = {
 
     return response.data;
   },
+  getMyStudyList: async () => {
+    const response = await fetcher.get<StudyListApiResponseDto[]>(
+      mentorApiPath.studyList,
+      {
+        next: { tags: [tags.myStudyList] },
+        cache: "force-cache",
+      }
+    );
+    return response.data;
+  },
   getStudyBasicInfo: async (studyId: number) => {
     const response = await fetcher.get<StudyBasicInfoApiResponseDto>(
       `/common/studies/${studyId}`,

--- a/apps/admin/app/studies/_components/StudyList.tsx
+++ b/apps/admin/app/studies/_components/StudyList.tsx
@@ -6,7 +6,8 @@ import EmptyStudyList from "./EmptyStudyList";
 import StudyListItem from "./StudyListItem";
 
 const StudyList = async () => {
-  const studyList = (await isAdmin())
+  const adminStatus = await isAdmin();
+  const studyList = adminStatus
     ? await studyApi.getStudyList()
     : await studyApi.getMyStudyList();
 

--- a/apps/admin/app/studies/_components/StudyList.tsx
+++ b/apps/admin/app/studies/_components/StudyList.tsx
@@ -1,11 +1,14 @@
 import { css } from "@styled-system/css";
 import { studyApi } from "apis/study/studyApi";
+import isAdmin from "utils/isAdmin";
 
 import EmptyStudyList from "./EmptyStudyList";
 import StudyListItem from "./StudyListItem";
 
 const StudyList = async () => {
-  const studyList = await studyApi.getStudyList();
+  const studyList = (await isAdmin())
+    ? await studyApi.getStudyList()
+    : await studyApi.getMyStudyList();
 
   if (studyList?.length === 0) {
     return <EmptyStudyList />;

--- a/apps/admin/app/studies/create-study/@modal/(.)created-study-check/page.tsx
+++ b/apps/admin/app/studies/create-study/@modal/(.)created-study-check/page.tsx
@@ -31,6 +31,7 @@ const CreatedStudyCheckModal = () => {
 
     if (result.success) {
       await revalidateTagByName(tags.studyList);
+      await revalidateTagByName(tags.myStudyList);
       window.alert("스터디 생성에 성공했어요.");
       router.push(`${routerPath.root.href}`);
     } else {

--- a/apps/admin/components/Navbar.tsx
+++ b/apps/admin/components/Navbar.tsx
@@ -17,7 +17,8 @@ import participantImageUrl from "../public/images/particpant.svg";
  */
 
 const Navbar = async () => {
-  const studyList = (await isAdmin())
+  const adminStatus = await isAdmin();
+  const studyList = adminStatus
     ? await studyApi.getStudyList()
     : await studyApi.getMyStudyList();
 

--- a/apps/admin/components/Navbar.tsx
+++ b/apps/admin/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import { css } from "@styled-system/css";
 import { NavItem } from "@wow-class/ui";
-import { dashboardApi } from "apis/auth/dashboardApi";
 import { studyApi } from "apis/study/studyApi";
 import { clientUrl } from "constants/url";
 import Image from "next/image";
@@ -20,7 +19,7 @@ import participantImageUrl from "../public/images/particpant.svg";
 const Navbar = async () => {
   const studyList = (await isAdmin())
     ? await studyApi.getStudyList()
-    : await dashboardApi.getMyStudyList();
+    : await studyApi.getMyStudyList();
 
   const navMenu = [
     {

--- a/apps/admin/constants/tags.ts
+++ b/apps/admin/constants/tags.ts
@@ -3,6 +3,7 @@ export const enum tags {
   assignments = "assignments",
   curriculums = "curriculums",
   studyList = "studyList",
+  myStudyList = "myStudyList",
   studyBasicInfo = "studyBasicInfo",
   announcements = "announcements",
   memberList = "memberList",

--- a/apps/admin/types/dtos/studyList.ts
+++ b/apps/admin/types/dtos/studyList.ts
@@ -1,9 +1,5 @@
 import type { DayOfWeekType } from "types/entities/dayofweek";
-import type {
-  StudyKoreanType,
-  StudySemesterType,
-  StudyType,
-} from "types/entities/study";
+import type { StudyKoreanType, StudySemesterType } from "types/entities/study";
 import type { TimeType } from "types/entities/time";
 
 export interface StudyListApiResponseDto {
@@ -19,13 +15,4 @@ export interface StudyListApiResponseDto {
   startTime: TimeType;
   totalWeek: number;
   openingDate: string;
-}
-
-export interface MyStudyListApiResponseDto {
-  studyId: number;
-  semester: string;
-  title: string;
-  studyType: StudyType;
-  notionLink: string;
-  mentorName: string;
 }


### PR DESCRIPTION
## 🎉 변경 사항
스터디 목록을 조회하는 화면을 멘토 권한을 갖고 있는 사람에게는 멘토용 API를 활용하도록 고쳤어요.
기존에는 멘토도 admin api를 활용하고 있어 에러페이지가 발생하였는데, 해당 이슈를 수정해요.
## 🚩 관련 이슈
https://gdschongik.slack.com/archives/C06Q93M2U81/p1725534956545469
