### PR TITLE
[Feature] 과제를 제출한 이후에도 레포지토리 수정 가능하도록 반영

### DIFF
--- a/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/AssignmentOverviewBox/AssignmentBoxButtons.tsx
+++ b/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/AssignmentOverviewBox/AssignmentBoxButtons.tsx
@@ -128,7 +128,7 @@ const SecondaryButton = ({
   const { year, month, day, hours, minutes } = parseISODate(
     committedAt as string
   );
-  const commitText = `최종 수정일자 ${year}년 ${month}월 ${day}일 ${padWithZero(hours)}:${padWithZero(minutes)}`;
+  const commitText = `최종 수정 일시 : ${year}년 ${month}월 ${day}일 ${padWithZero(hours)}:${padWithZero(minutes)}`;
 
   return (
     <Button

--- a/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/AssignmentOverviewBox/index.tsx
+++ b/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/AssignmentOverviewBox/index.tsx
@@ -57,6 +57,7 @@ export const AssignmentOverviewBox = async ({
                   target="_blank"
                   text="과제 명세 확인"
                 />
+                <Space height={8} />
                 <AssignmentBoxInfo
                   assignment={assignment}
                   repositoryLink={repositoryLink}

--- a/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/RepositorySubmissionBox.tsx
+++ b/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/RepositorySubmissionBox.tsx
@@ -21,6 +21,8 @@ interface RepositorySubmissionBoxProps {
   repositoryLink: string;
 }
 
+const repositoryInfoMessage = "과제 제출 후에도 레포지토리 수정이 가능해요.";
+
 export const RepositorySubmissionBox = ({
   repositoryLink: initialRepositoryUrl,
 }: RepositorySubmissionBoxProps) => {
@@ -124,9 +126,7 @@ export const RepositorySubmissionBox = ({
             <>
               {repositorySubmissionStatus === "SUBMITTED" && (
                 <>
-                  <Text color="sub">
-                    최초 과제 제출 전 까지만 수정이 가능해요.
-                  </Text>
+                  <Text color="sub">{repositoryInfoMessage}</Text>
                   <Space height={26} />
                   <Flex className={urlBoxStyle}>
                     <div className={overflowTextStyle}>{repositoryUrl}</div>
@@ -184,7 +184,7 @@ export const RepositorySubmissionBox = ({
           <Flex alignItems="center" direction="column" width="21rem">
             <Text typo="h1">레포지토리를 입력하시겠어요?</Text>
             <Space height={12} />
-            <Text color="sub">최초 과제 제출 전까지 수정이 가능해요.</Text>
+            <Text color="sub">{repositoryInfoMessage}</Text>
             <Space height={8} />
             <div className={modalUrlBoxStyle}>{repositoryUrl}</div>
             <Space height={28} />
@@ -219,9 +219,6 @@ const modalUrlBoxStyle = css({
   paddingX: "lg",
   paddingY: "sm",
   textStyle: "h2",
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
   width: "375px",
 });
 const boxStyle = {

--- a/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/index.tsx
+++ b/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/index.tsx
@@ -33,17 +33,22 @@ export const AssignmentContent = async () => {
     );
   }
 
+  const isAnyFirstWeekAssignment = studyDashboard.submittableAssignments.some(
+    ({ week }) => week === 1
+  );
   return (
     <section>
-      <Flex className={boxContainerStyle} gap="lg">
-        {studyDashboard.isLinkEditable && (
-          <RepositorySubmissionBox
-            repositoryLink={studyDashboard.repositoryLink}
-          />
-        )}
+      <Flex
+        className={boxContainerStyle}
+        flexDirection={isAnyFirstWeekAssignment ? "row-reverse" : "row"}
+        gap="lg"
+      >
         <AssignmentOverviewBox
           assignments={studyDashboard.submittableAssignments}
           buttonsDisabled={!studyDashboard.repositoryLink}
+          repositoryLink={studyDashboard.repositoryLink}
+        />
+        <RepositorySubmissionBox
           repositoryLink={studyDashboard.repositoryLink}
         />
       </Flex>

--- a/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/index.tsx
+++ b/apps/client/app/(afterLogin)/my-study/my-assignment/_components/AssignmentContent/index.tsx
@@ -43,11 +43,13 @@ export const AssignmentContent = async () => {
         flexDirection={isAnyFirstWeekAssignment ? "row-reverse" : "row"}
         gap="lg"
       >
-        <AssignmentOverviewBox
-          assignments={studyDashboard.submittableAssignments}
-          buttonsDisabled={!studyDashboard.repositoryLink}
-          repositoryLink={studyDashboard.repositoryLink}
-        />
+        <Flex flexDirection="row" gap="lg">
+          <AssignmentOverviewBox
+            assignments={studyDashboard.submittableAssignments}
+            buttonsDisabled={!studyDashboard.repositoryLink}
+            repositoryLink={studyDashboard.repositoryLink}
+          />
+        </Flex>
         <RepositorySubmissionBox
           repositoryLink={studyDashboard.repositoryLink}
         />


### PR DESCRIPTION
<!-- 제목: [Feature] PR내용
ex) [Feature] 프로젝트 초기 세팅 -->

## 🎉 변경 사항
- 과제를 제출한 이후에도 레포지토리 수정 가능하도록 반영합니다.
-  1주차 과제가 있을 때에는 레포지토리 박스가 왼쪽에, 없을 때에는 오른쪽에 정렬되도록 합니다.
   - 1주차가 아닐 떄에는 과제 제출에 중점을 두기 위함입니다. [피그마 댓글 참조](https://www.figma.com/design/QiV7CzZdMvMbKqBEfVCkIJ?node-id=3591-7762#1073189353)

- 1주차 과제가 있을 때(레포지토리 박스 왼쪽에 위치)
![image](https://github.com/user-attachments/assets/e3c65095-519d-4b48-b914-0c44680b815a)
- 1주차 과제가 없을 때(레포지토리 박스 오른쪽에 위치)
![image](https://github.com/user-attachments/assets/4358b4eb-dbb4-4c85-baf7-f406918a3e0b)

## 🚩 관련 이슈
https://gdgochongik.slack.com/archives/C06NHDMLRUM/p1734321591179539

## 🙏 여기는 꼭 봐주세요!
