### PR TITLE
[Feature] 어드민 스터디 상세 페이지 v2 버전 작업 2차

### DIFF
--- a/apps/admin/apis/study/studyApi.ts
+++ b/apps/admin/apis/study/studyApi.ts
@@ -165,7 +165,7 @@ export const studyApi = {
   },
   getStudyStatistics: async (studyId: number) => {
     const response = await fetcher.get<StudyStatisticsApiResponseDto>(
-      `/mentor/study-details/statistics?studyId=${studyId}`,
+      `/v2/mentor/studies/${studyId}/statistics`,
       {
         next: { tags: [tags.statistics] },
       }

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
@@ -5,7 +5,7 @@ import type { StudySessionApiResponseV2Dto } from "types/dtos/studyList";
 import CurriculumListItem from "./CurriculumListItem";
 import EmptyCurriculumList from "./EmptyCurriculumList";
 
-const CurriculumList = async ({
+const CurriculumList = ({
   studySessions,
 }: {
   studySessions?: StudySessionApiResponseV2Dto[];

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
@@ -1,27 +1,15 @@
+import { Flex } from "@styled-system/jsx";
 import { Space, Text } from "@wow-class/ui";
-import { studyApi } from "apis/study/studyApi";
 import type { StudySessionApiResponseV2Dto } from "types/dtos/studyList";
 
 import CurriculumListItem from "./CurriculumListItem";
 import EmptyCurriculumList from "./EmptyCurriculumList";
 
 const CurriculumList = async ({
-  studyId,
   studySessions,
 }: {
-  studyId: string;
   studySessions?: StudySessionApiResponseV2Dto[];
 }) => {
-  {
-    /*
-  const curriculumList = await studyApi.getCurriculumList(
-    parseInt(studyId, 10)
-  );
-    */
-  }
-
-  console.log("test", studySessions);
-
   if (studySessions?.length === 0) {
     return <EmptyCurriculumList />;
   }
@@ -30,12 +18,14 @@ const CurriculumList = async ({
     <section aria-label="curriculum-list">
       <Text typo="h2">스터디 커리큘럼</Text>
       <Space height={50} />
-      {studySessions?.map((curriculum) => (
-        <CurriculumListItem
-          curriculum={curriculum}
-          key={curriculum.studySessionId}
-        />
-      ))}
+      <Flex direction="column" gap="50px">
+        {studySessions?.map((curriculum) => (
+          <CurriculumListItem
+            curriculum={curriculum}
+            key={curriculum.studySessionId}
+          />
+        ))}
+      </Flex>
     </section>
   );
 };

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
@@ -1,26 +1,39 @@
 import { Space, Text } from "@wow-class/ui";
 import { studyApi } from "apis/study/studyApi";
+import type { StudySessionApiResponseV2Dto } from "types/dtos/studyList";
 
 import CurriculumListItem from "./CurriculumListItem";
 import EmptyCurriculumList from "./EmptyCurriculumList";
 
-const CurriculumList = async ({ studyId }: { studyId: string }) => {
+const CurriculumList = async ({
+  studyId,
+  studySessions,
+}: {
+  studyId: string;
+  studySessions?: StudySessionApiResponseV2Dto[];
+}) => {
+  {
+    /*
   const curriculumList = await studyApi.getCurriculumList(
     parseInt(studyId, 10)
   );
+    */
+  }
 
-  if (curriculumList?.length === 0) {
+  console.log("test", studySessions);
+
+  if (studySessions?.length === 0) {
     return <EmptyCurriculumList />;
   }
 
   return (
     <section aria-label="curriculum-list">
       <Text typo="h2">스터디 커리큘럼</Text>
-      <Space height={24} />
-      {curriculumList?.map((curriculum) => (
+      <Space height={50} />
+      {studySessions?.map((curriculum) => (
         <CurriculumListItem
           curriculum={curriculum}
-          key={`curriculumItem-${curriculum.studyDetailId}`}
+          key={curriculum.studySessionId}
         />
       ))}
     </section>

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumList.tsx
@@ -7,8 +7,10 @@ import EmptyCurriculumList from "./EmptyCurriculumList";
 
 const CurriculumList = ({
   studySessions,
+  studyType,
 }: {
   studySessions?: StudySessionApiResponseV2Dto[];
+  studyType?: string;
 }) => {
   if (studySessions?.length === 0) {
     return <EmptyCurriculumList />;
@@ -23,6 +25,7 @@ const CurriculumList = ({
           <CurriculumListItem
             curriculum={curriculum}
             key={curriculum.studySessionId}
+            studyType={studyType}
           />
         ))}
       </Flex>

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -1,13 +1,15 @@
 import { cva } from "@styled-system/css";
 import { Flex } from "@styled-system/jsx";
-import { Table, Text } from "@wow-class/ui";
+import { Space, Table, Text } from "@wow-class/ui";
 import { padWithZero, parseISODate } from "@wow-class/utils";
 import type { ComponentProps } from "react";
 import type { CurriculumApiResponseDto } from "types/dtos/curriculumList";
 import type { StudySessionApiResponseV2Dto } from "types/dtos/studyList";
 import type { StudyDifficultyType } from "types/entities/study";
+import { displayPartsToString } from "typescript";
 import getIsCurrentWeek from "utils/getIsCurrentWeek";
 import { color } from "wowds-tokens";
+import Box from "wowds-ui/Box";
 import type Tag from "wowds-ui/Tag";
 
 const CurriculumListItem = ({
@@ -60,10 +62,8 @@ const CurriculumListItem = ({
 
   return (
     <Table>
-      {" "}
-      {/* height:80px => minHeight:80px 변경하거나 Flex로 변경하기 */}
       <Table.Left>
-        <Flex alignItems="baseline" gap="28px">
+        <Flex alignItems="baseline" gap="48px">
           <Flex direction="column" minWidth={52}>
             <Text typo="body1">{position}회차</Text>
             <Text color="sub" typo="body2">
@@ -73,6 +73,7 @@ const CurriculumListItem = ({
               {startTime}-{endTime}
             </Text>
           </Flex>
+
           <Flex direction="column" gap="xxs">
             <Flex alignItems="center" gap="xs">
               <Text typo="h3">
@@ -82,17 +83,26 @@ const CurriculumListItem = ({
             <Text color="sub" style={CurriculumDescriptionStyle} typo="body2">
               {description || "스터디 상세 설명을 작성해주세요."}
             </Text>
-            <Flex
-              direction="column"
-              gap="-md"
+            <Space height={18.5} />
+            <Box
               style={AssignmentDescriptionStyle}
-            >
-              <Text>{assignmentTitle}</Text>
-              <Text color="primary" typo="body2">
-                과제 기간: {assignmentStartMonth}월 {assignmentStartDay}일 ~{" "}
-                {assignmentEndMonth}월 {assignmentEndDay}일 {assignmentEndTime}
-              </Text>
-            </Flex>
+              text={
+                <Flex
+                  direction="column"
+                  gap="xxs"
+                  style={AssignmentDescriptionStyle}
+                  width="100%"
+                >
+                  <Text>{assignmentTitle}</Text>
+                  <Text color="primary" typo="body2">
+                    과제 기간: {assignmentStartMonth}월 {assignmentStartDay}일 ~{" "}
+                    {assignmentEndMonth}월 {assignmentEndDay}일{" "}
+                    {assignmentEndTime}
+                  </Text>
+                </Flex>
+              }
+            />
+            <Space height={50} />
           </Flex>
         </Flex>
       </Table.Left>
@@ -102,47 +112,11 @@ const CurriculumListItem = ({
 
 export default CurriculumListItem;
 
-const ThisWeekBarStyle = cva({
-  base: {
-    width: "4px",
-    height: "18px",
-  },
-  variants: {
-    type: {
-      thisWeek: {
-        backgroundColor: "primary",
-      },
-      notThisWeek: {
-        backgroundColor: "transparent",
-      },
-    },
-  },
-});
-
-const DifficultyMap: Record<
-  StudyDifficultyType,
-  { text: string; color: ComponentProps<typeof Tag>["color"] }
-> = {
-  HIGH: {
-    text: "고급",
-    color: "red",
-  },
-  MEDIUM: {
-    text: "중급",
-    color: "green",
-  },
-  LOW: {
-    text: "기초",
-    color: "blue",
-  },
-  BASIC: {
-    text: "초급",
-    color: "yellow",
-  },
-};
-
 const CurriculumDescriptionStyle = {
   maxWidth: "650px",
 };
 
-const AssignmentDescriptionStyle = {};
+const AssignmentDescriptionStyle = {
+  flex: 1,
+  width: "100%",
+};

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -11,16 +11,12 @@ const CurriculumListItem = ({
   curriculum: StudySessionApiResponseV2Dto;
 }) => {
   const {
-    studySessionId,
     position,
     lessonTitle,
     description = "",
-    lessonAttendanceNumber,
     lessonPeriod,
     assignmentTitle,
-    assignmentDescriptionLink,
     assignmentPeriod,
-    studyId,
   } = curriculum;
   const { startDate, endDate } = lessonPeriod;
   const {
@@ -55,20 +51,20 @@ const CurriculumListItem = ({
 
   return (
     <Table>
-      <Table.Left>
-        <Flex alignItems="baseline" gap="48px">
+      <Table.Left style={{ width: "100%" }}>
+        <Flex alignItems="baseline" gap="48px" width="100%">
           <Flex direction="column" minWidth={52}>
             <Text typo="body1">{position}회차</Text>
             <Text color="sub" typo="body2">
               {startMonth}월 {startDay}일
             </Text>
-            <Text color="sub" typo="body2">
+            <Text color="sub" style={{ whiteSpace: "nowrap" }} typo="body2">
               {startTime}-{endTime}
             </Text>
           </Flex>
 
-          <Flex direction="column" gap="xxs">
-            <Flex alignItems="center" gap="xs">
+          <Flex direction="column" gap="xxs" width="100%">
+            <Flex alignItems="center" gap="xs" width="100%">
               <Text typo="h3">
                 {lessonTitle || "스터디 제목을 작성해주세요."}
               </Text>
@@ -86,7 +82,7 @@ const CurriculumListItem = ({
                   style={AssignmentDescriptionStyle}
                   width="100%"
                 >
-                  <Text>{assignmentTitle}</Text>
+                  <Text>{assignmentTitle || "과제 제목을 입력해주세요"}</Text>
                   <Text color="primary" typo="body2">
                     과제 기간: {assignmentStartMonth}월 {assignmentStartDay}일 ~{" "}
                     {assignmentEndMonth}월 {assignmentEndDay}일{" "}
@@ -111,4 +107,5 @@ const CurriculumDescriptionStyle = {
 const AssignmentDescriptionStyle = {
   flex: 1,
   width: "100%",
+  minWidth: "100%",
 };

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -7,8 +7,10 @@ import Box from "wowds-ui/Box";
 
 const CurriculumListItem = ({
   curriculum,
+  studyType,
 }: {
   curriculum: StudySessionApiResponseV2Dto;
+  studyType?: string;
 }) => {
   const {
     position,
@@ -49,6 +51,9 @@ const CurriculumListItem = ({
             <Text typo="body1">{position}회차</Text>
             <Text color="sub" typo="body2">
               {startMonth}월 {startDay}일
+            </Text>
+            <Text color="sub" style={TimeStyle} typo="body2">
+              {studyType !== "ASSIGNMENT" && `${startTime}-${endTime}`}
             </Text>
           </Flex>
 
@@ -102,3 +107,5 @@ const AssignmentDescriptionStyle = {
   width: "100%",
   minWidth: "100%",
 };
+
+const TimeStyle = { whiteSpace: "nowrap" };

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -25,19 +25,11 @@ const CurriculumListItem = ({
     hours: startHour,
     minutes: startMinute,
   } = parseISODate(startDate);
-  const {
-    month: endMonth,
-    day: endDay,
-    hours: endHour,
-    minutes: endMinute,
-  } = parseISODate(endDate);
+  const { hours: endHour, minutes: endMinute } = parseISODate(endDate);
 
-  const {
-    month: assignmentStartMonth,
-    day: assignmentStartDay,
-    hours: assignmentStartHour,
-    minutes: assignmentStartMinute,
-  } = parseISODate(assignmentPeriod.startDate);
+  const { month: assignmentStartMonth, day: assignmentStartDay } = parseISODate(
+    assignmentPeriod.startDate
+  );
   const {
     month: assignmentEndMonth,
     day: assignmentEndDay,
@@ -57,9 +49,6 @@ const CurriculumListItem = ({
             <Text typo="body1">{position}회차</Text>
             <Text color="sub" typo="body2">
               {startMonth}월 {startDay}일
-            </Text>
-            <Text color="sub" style={{ whiteSpace: "nowrap" }} typo="body2">
-              {startTime}-{endTime}
             </Text>
           </Flex>
 
@@ -83,7 +72,11 @@ const CurriculumListItem = ({
                   width="100%"
                 >
                   <Text>{assignmentTitle || "과제 제목을 입력해주세요"}</Text>
-                  <Text color="primary" typo="body2">
+                  <Text
+                    color="primary"
+                    style={{ whiteSpace: "nowrap" }}
+                    typo="body2"
+                  >
                     과제 기간: {assignmentStartMonth}월 {assignmentStartDay}일 ~{" "}
                     {assignmentEndMonth}월 {assignmentEndDay}일{" "}
                     {assignmentEndTime}

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -2,15 +2,8 @@ import { cva } from "@styled-system/css";
 import { Flex } from "@styled-system/jsx";
 import { Space, Table, Text } from "@wow-class/ui";
 import { padWithZero, parseISODate } from "@wow-class/utils";
-import type { ComponentProps } from "react";
-import type { CurriculumApiResponseDto } from "types/dtos/curriculumList";
 import type { StudySessionApiResponseV2Dto } from "types/dtos/studyList";
-import type { StudyDifficultyType } from "types/entities/study";
-import { displayPartsToString } from "typescript";
-import getIsCurrentWeek from "utils/getIsCurrentWeek";
-import { color } from "wowds-tokens";
 import Box from "wowds-ui/Box";
-import type Tag from "wowds-ui/Tag";
 
 const CurriculumListItem = ({
   curriculum,
@@ -102,7 +95,6 @@ const CurriculumListItem = ({
                 </Flex>
               }
             />
-            <Space height={50} />
           </Flex>
         </Flex>
       </Table.Left>

--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -4,67 +4,98 @@ import { Table, Text } from "@wow-class/ui";
 import { padWithZero, parseISODate } from "@wow-class/utils";
 import type { ComponentProps } from "react";
 import type { CurriculumApiResponseDto } from "types/dtos/curriculumList";
+import type { StudySessionApiResponseV2Dto } from "types/dtos/studyList";
 import type { StudyDifficultyType } from "types/entities/study";
 import getIsCurrentWeek from "utils/getIsCurrentWeek";
-import Tag from "wowds-ui/Tag";
+import { color } from "wowds-tokens";
+import type Tag from "wowds-ui/Tag";
 
 const CurriculumListItem = ({
   curriculum,
 }: {
-  curriculum: CurriculumApiResponseDto;
+  curriculum: StudySessionApiResponseV2Dto;
 }) => {
   const {
+    studySessionId,
+    position,
+    lessonTitle,
     description = "",
-    period,
-    week,
-    title,
-    difficulty,
-    curriculumStatus,
+    lessonAttendanceNumber,
+    lessonPeriod,
+    assignmentTitle,
+    assignmentDescriptionLink,
+    assignmentPeriod,
+    studyId,
   } = curriculum;
-  const { startDate, endDate } = period;
-  const { month: startMonth, day: startDay } = parseISODate(startDate);
-  const { month: endMonth, day: endDay } = parseISODate(endDate);
+  const { startDate, endDate } = lessonPeriod;
+  const {
+    month: startMonth,
+    day: startDay,
+    hours: startHour,
+    minutes: startMinute,
+  } = parseISODate(startDate);
+  const {
+    month: endMonth,
+    day: endDay,
+    hours: endHour,
+    minutes: endMinute,
+  } = parseISODate(endDate);
 
-  const curriculumTimeLine = `${padWithZero(startMonth)}.${padWithZero(startDay)} - ${padWithZero(endMonth)}.${padWithZero(endDay)}`;
-  const thisWeekAssignment = getIsCurrentWeek(startDate);
+  const {
+    month: assignmentStartMonth,
+    day: assignmentStartDay,
+    hours: assignmentStartHour,
+    minutes: assignmentStartMinute,
+  } = parseISODate(assignmentPeriod.startDate);
+  const {
+    month: assignmentEndMonth,
+    day: assignmentEndDay,
+    hours: assignmentEndHour,
+    minutes: assignmentEndMinute,
+  } = parseISODate(assignmentPeriod.endDate);
+
+  const startTime = `${padWithZero(startHour)}:${padWithZero(startMinute)}`;
+  const endTime = `${padWithZero(endHour)}:${padWithZero(endMinute)}`;
+  const assignmentEndTime = `${padWithZero(assignmentEndHour)}:${padWithZero(assignmentEndMinute)}`;
 
   return (
     <Table>
+      {" "}
+      {/* height:80px => minHeight:80px 변경하거나 Flex로 변경하기 */}
       <Table.Left>
-        <Flex alignItems="center" gap="28px">
-          <Flex alignItems="center" gap="xxs">
-            <div
-              className={ThisWeekBarStyle({
-                type: thisWeekAssignment ? "thisWeek" : "notThisWeek",
-              })}
-            />
-            <Flex direction="column" minWidth={52}>
-              <Text typo="body1">{week}주차</Text>
-              {curriculumStatus === "CANCELED" && (
-                <Text color="sub" typo="body2">
-                  휴강 주차
-                </Text>
-              )}
-            </Flex>
+        <Flex alignItems="baseline" gap="28px">
+          <Flex direction="column" minWidth={52}>
+            <Text typo="body1">{position}회차</Text>
+            <Text color="sub" typo="body2">
+              {startMonth}월 {startDay}일
+            </Text>
+            <Text color="sub" typo="body2">
+              {startTime}-{endTime}
+            </Text>
           </Flex>
           <Flex direction="column" gap="xxs">
             <Flex alignItems="center" gap="xs">
-              <Text typo="h3">{title || "-"}</Text>
-              {difficulty && (
-                <Tag color={DifficultyMap[difficulty].color} variant="outline">
-                  {DifficultyMap[difficulty].text}
-                </Tag>
-              )}
+              <Text typo="h3">
+                {lessonTitle || "스터디 제목을 작성해주세요."}
+              </Text>
             </Flex>
             <Text color="sub" style={CurriculumDescriptionStyle} typo="body2">
               {description || "스터디 상세 설명을 작성해주세요."}
             </Text>
+            <Flex
+              direction="column"
+              gap="-md"
+              style={AssignmentDescriptionStyle}
+            >
+              <Text>{assignmentTitle}</Text>
+              <Text color="primary" typo="body2">
+                과제 기간: {assignmentStartMonth}월 {assignmentStartDay}일 ~{" "}
+                {assignmentEndMonth}월 {assignmentEndDay}일 {assignmentEndTime}
+              </Text>
+            </Flex>
           </Flex>
         </Flex>
       </Table.Left>
-      <Table.Right>
-        <Text typo="body1">{curriculumTimeLine}</Text>
-      </Table.Right>
     </Table>
   );
 };
@@ -113,3 +144,5 @@ const DifficultyMap: Record<
 const CurriculumDescriptionStyle = {
   maxWidth: "650px",
 };
+
+const AssignmentDescriptionStyle = {};

--- a/apps/admin/app/studies/[studyId]/_components/statics/StudyAnalyticsGraph.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/statics/StudyAnalyticsGraph.tsx
@@ -31,7 +31,7 @@ const StudyAnalyticsGraph = ({
                 color="sub"
                 typo="body1"
               >
-                {data.round}주차
+                {data.round}회차
               </Text>
               <BarGraph
                 isCurriculumCanceled={false}

--- a/apps/admin/app/studies/[studyId]/_components/statics/StudyAnalyticsGraph.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/statics/StudyAnalyticsGraph.tsx
@@ -16,7 +16,6 @@ const StudyAnalyticsGraph = ({
   totalStudent?: number;
   studyRoundStatisticsDtos?: studyRoundStatisticsDtos[];
 }) => {
-  console.log(studyRoundStatisticsDtos, "test");
   return (
     <Flex direction="column" gap="md">
       <Text className={staticsTitleStyle} typo="h3">

--- a/apps/admin/app/studies/[studyId]/_components/statics/StudyAnalyticsGraph.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/statics/StudyAnalyticsGraph.tsx
@@ -1,7 +1,7 @@
 import { css } from "@styled-system/css";
 import { Flex } from "@styled-system/jsx";
 import { Text } from "@wow-class/ui";
-import type { StudyWeekStatisticsApiResponseDto } from "types/dtos/studyStatistics";
+import type { studyRoundStatisticsDtos } from "types/dtos/studyStatistics";
 
 import BarGraph from "./graph/BarGraph";
 
@@ -9,13 +9,14 @@ const StudyAnalyticsGraph = ({
   graphTitle,
   averageRate = 0,
   totalStudent,
-  studyWeekStatisticsResponses,
+  studyRoundStatisticsDtos,
 }: {
   graphTitle: string;
   averageRate?: number;
   totalStudent?: number;
-  studyWeekStatisticsResponses?: StudyWeekStatisticsApiResponseDto[];
+  studyRoundStatisticsDtos?: studyRoundStatisticsDtos[];
 }) => {
+  console.log(studyRoundStatisticsDtos, "test");
   return (
     <Flex direction="column" gap="md">
       <Text className={staticsTitleStyle} typo="h3">
@@ -23,18 +24,18 @@ const StudyAnalyticsGraph = ({
       </Text>
       <Flex direction="column" gap="xs">
         <Flex alignItems="flex-start" direction="column" gap="md">
-          {studyWeekStatisticsResponses?.map((data) => (
-            <Flex direction="row" gap="lg" key={data.week} minWidth="340px">
+          {studyRoundStatisticsDtos?.map((data) => (
+            <Flex direction="row" gap="lg" key={data.round} minWidth="340px">
               <Text
                 as="div"
                 className={studyWeekStyle}
                 color="sub"
                 typo="body1"
               >
-                {data.week}주차
+                {data.round}주차
               </Text>
               <BarGraph
-                isCurriculumCanceled={data.isCurriculumCanceled}
+                isCurriculumCanceled={false}
                 percent={data.attendanceRate}
                 totalStudent={totalStudent}
               />

--- a/apps/admin/app/studies/[studyId]/_components/statics/StudyStatics.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/statics/StudyStatics.tsx
@@ -9,7 +9,6 @@ const StudyStatics = async ({ studyId }: { studyId: string }) => {
   const studyStatistics = await studyApi.getStudyStatistics(
     parseInt(studyId, 10)
   );
-
   return (
     <section aria-label="study-statics">
       <Flex direction="column" gap="sm">
@@ -24,18 +23,14 @@ const StudyStatics = async ({ studyId }: { studyId: string }) => {
         <StudyAnalyticsGraph
           averageRate={studyStatistics?.averageAttendanceRate}
           graphTitle="출석률"
+          studyRoundStatisticsDtos={studyStatistics?.studyRoundStatisticsDtos}
           totalStudent={studyStatistics?.totalStudentCount}
-          studyWeekStatisticsResponses={
-            studyStatistics?.studyWeekStatisticsResponses
-          }
         />
         <StudyAnalyticsGraph
           averageRate={studyStatistics?.averageAssignmentSubmissionRate}
           graphTitle="과제 제출률"
+          studyRoundStatisticsDtos={studyStatistics?.studyRoundStatisticsDtos}
           totalStudent={studyStatistics?.totalStudentCount}
-          studyWeekStatisticsResponses={
-            studyStatistics?.studyWeekStatisticsResponses
-          }
         />
         <StudyCompleteRate
           studyCompleteCount={studyStatistics?.completeStudentCount}

--- a/apps/admin/app/studies/[studyId]/page.tsx
+++ b/apps/admin/app/studies/[studyId]/page.tsx
@@ -50,13 +50,9 @@ const StudyPage = async ({ params }: { params: { studyId: string } }) => {
       {/* <Divider style={MinHeightFullDividerStyle} /> */}
 
       <Divider style={MinHeightFullDividerStyle} />
-      <CurriculumList
-        studyId={studyId}
-        studySessions={myStudy?.studySessions}
-      />
-      {/*
+      <CurriculumList studySessions={myStudy?.studySessions} />
       <Divider style={MinHeightFullDividerStyle} />
-      <StudyStatics studyId={studyId} /> */}
+      <StudyStatics studyId={studyId} />
     </Flex>
   );
 };

--- a/apps/admin/app/studies/[studyId]/page.tsx
+++ b/apps/admin/app/studies/[studyId]/page.tsx
@@ -47,10 +47,14 @@ const StudyPage = async ({ params }: { params: { studyId: string } }) => {
       <Divider style={MinHeightFullDividerStyle} />
       <StudyAnnouncement studyId={studyId} />
       {/* <AssignmentList studyId={studyId} /> */}
-      {/* <Divider style={MinHeightFullDividerStyle} />
-      
+      {/* <Divider style={MinHeightFullDividerStyle} /> */}
+
       <Divider style={MinHeightFullDividerStyle} />
-      <CurriculumList studyId={studyId} />
+      <CurriculumList
+        studyId={studyId}
+        studySessions={myStudy?.studySessions}
+      />
+      {/*
       <Divider style={MinHeightFullDividerStyle} />
       <StudyStatics studyId={studyId} /> */}
     </Flex>

--- a/apps/admin/app/studies/[studyId]/page.tsx
+++ b/apps/admin/app/studies/[studyId]/page.tsx
@@ -46,9 +46,6 @@ const StudyPage = async ({ params }: { params: { studyId: string } }) => {
       <AttendanceList studySessions={myStudy?.studySessions} />
       <Divider style={MinHeightFullDividerStyle} />
       <StudyAnnouncement studyId={studyId} />
-      {/* <AssignmentList studyId={studyId} /> */}
-      {/* <Divider style={MinHeightFullDividerStyle} /> */}
-
       <Divider style={MinHeightFullDividerStyle} />
       <CurriculumList studySessions={myStudy?.studySessions} />
       <Divider style={MinHeightFullDividerStyle} />

--- a/apps/admin/app/studies/[studyId]/page.tsx
+++ b/apps/admin/app/studies/[studyId]/page.tsx
@@ -32,6 +32,8 @@ const StudyPage = async ({ params }: { params: { studyId: string } }) => {
     ? await studyApi.getStudyList()
     : await studyApi.getMyStudyList();
   const myStudy = data?.filter((study) => study.study.studyId === +studyId)[0];
+  const studyType = (await studyApi.getStudyBasicInfo(+studyId))?.type;
+
   return (
     <Flex direction="column" gap="64px">
       <div className={HeaderWrapper}>
@@ -47,7 +49,10 @@ const StudyPage = async ({ params }: { params: { studyId: string } }) => {
       <Divider style={MinHeightFullDividerStyle} />
       <StudyAnnouncement studyId={studyId} />
       <Divider style={MinHeightFullDividerStyle} />
-      <CurriculumList studySessions={myStudy?.studySessions} />
+      <CurriculumList
+        studySessions={myStudy?.studySessions}
+        studyType={studyType}
+      />
       <Divider style={MinHeightFullDividerStyle} />
       <StudyStatics studyId={studyId} />
     </Flex>

--- a/apps/admin/types/dtos/studyStatistics.ts
+++ b/apps/admin/types/dtos/studyStatistics.ts
@@ -4,13 +4,11 @@ export interface StudyStatisticsApiResponseDto {
   averageAttendanceRate: number;
   averageAssignmentSubmissionRate: number;
   studyCompleteRate: number;
-  studyWeekStatisticsResponses: StudyWeekStatisticsApiResponseDto[];
+  studyRoundStatisticsDtos: studyRoundStatisticsDtos[];
 }
 
-export interface StudyWeekStatisticsApiResponseDto {
-  week: number;
+export interface studyRoundStatisticsDtos {
+  round: number;
   attendanceRate: number;
   assignmentSubmissionRate: number;
-  isAssignmentCanceled: boolean;
-  isCurriculumCanceled: boolean;
 }

--- a/packages/ui/src/components/Table/index.tsx
+++ b/packages/ui/src/components/Table/index.tsx
@@ -14,9 +14,9 @@ const Table = ({ children, ...rest }: TableProps) => {
   return (
     <Flex
       alignItems="center"
-      height="80px"
       justifyContent="space-between"
       marginBottom="12px"
+      minHeight="80px"
       width="100%"
       {...rest}
     >

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -441,8 +441,8 @@ progress {
 .h_20px:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
   height: 20px;
 }
-.h_80px:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
-  height: 80px;
+.min-h_80px:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 80px;
 }
 .w_100\%:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
   width: 100%;


### PR DESCRIPTION
## 🎉 변경 사항
어드민 스터디 상세 페이지 api를 v2로 변경하였습니다.

- 스터디 커리큘럼, 과제
- 스터디 통계

## 🚩 관련 이슈
스터디 커리큘럼, 과제 부분 UI 크기 조정에서 어려움을 겪고 있습니다!

- 스터디 과제 정보가 들어가 있는 `<Box>` 컴포넌트
- `<Box>`의 `width`가 100%가 안됨.. ㅜㅜ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 커리큘럼 리스트가 API 호출 대신 직접 제공된 세션 데이터를 사용하도록 전환되어 데이터 처리와 항목 표시가 개선되었습니다.
  - 커리큘럼 항목의 강의 및 과제 정보와 일정이 재구성되어 정보 전달이 명확해졌습니다.
  - 통계 그래프에서 주간 통계 대신 라운드 통계 데이터로 변경되어 정보의 일관성이 향상되었습니다.
  - 스터디 페이지에서 커리큘럼 리스트에 전달되는 데이터가 업데이트되었습니다.
  
- **Style**
  - 레이아웃 간격과 구성 요소 배치가 개선되어 보다 깔끔한 사용자 인터페이스를 제공합니다.
  - 테이블 및 관련 스타일이 업데이트되어 유연한 높이 조절이 가능해졌습니다.
  - CSS 클래스가 수정되어 요소의 최소 높이가 설정되어 레이아웃의 유연성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->