### PR TITLE
[Fix] 어드민 스터디 상세 페이지 오류 수정

### DIFF
--- a/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
+++ b/apps/admin/app/studies/[studyId]/_components/curriculum/CurriculumListItem.tsx
@@ -21,14 +21,33 @@ const CurriculumListItem = ({
     assignmentTitle,
     assignmentPeriod,
   } = curriculum;
-  const { startDate, endDate } = lessonPeriod;
-  const {
-    month: startMonth,
-    day: startDay,
-    hours: startHour,
-    minutes: startMinute,
-  } = parseISODate(startDate);
-  const { hours: endHour, minutes: endMinute } = parseISODate(endDate);
+  const lessonSchedule = () => {
+    if (lessonPeriod) {
+      const { startDate, endDate } = lessonPeriod;
+      const {
+        month: startMonth,
+        day: startDay,
+        hours: startHour,
+        minutes: startMinute,
+      } = parseISODate(startDate);
+      const { hours: endHour, minutes: endMinute } = parseISODate(endDate);
+      const startTime = `${padWithZero(startHour)}:${padWithZero(startMinute)}`;
+      const endTime = `${padWithZero(endHour)}:${padWithZero(endMinute)}`;
+
+      return (
+        <>
+          <Text color="sub" typo="body2">
+            {startMonth}월 {startDay}일
+          </Text>
+          <Text color="sub" style={TimeStyle} typo="body2">
+            {startTime}-{endTime}
+          </Text>
+        </>
+      );
+    } else {
+      null;
+    }
+  };
 
   const { month: assignmentStartMonth, day: assignmentStartDay } = parseISODate(
     assignmentPeriod.startDate
@@ -40,8 +59,6 @@ const CurriculumListItem = ({
     minutes: assignmentEndMinute,
   } = parseISODate(assignmentPeriod.endDate);
 
-  const startTime = `${padWithZero(startHour)}:${padWithZero(startMinute)}`;
-  const endTime = `${padWithZero(endHour)}:${padWithZero(endMinute)}`;
   const assignmentEndTime = `${padWithZero(assignmentEndHour)}:${padWithZero(assignmentEndMinute)}`;
 
   return (
@@ -50,16 +67,7 @@ const CurriculumListItem = ({
         <Flex gap="48px" width="100%">
           <Flex direction="column" minWidth={52}>
             <Text typo="body1">{position}회차</Text>
-            {isOnlineOfflineStudyType(studyType) && (
-              <>
-                <Text color="sub" typo="body2">
-                  {startMonth}월 {startDay}일
-                </Text>
-                <Text color="sub" style={TimeStyle} typo="body2">
-                  {startTime}-{endTime}
-                </Text>
-              </>
-            )}
+            {isOnlineOfflineStudyType(studyType) && lessonSchedule()}
           </Flex>
 
           <Flex direction="column" gap="xxs" width="100%">


### PR DESCRIPTION
## 🎉 변경 사항

- 과제 스터디의 커리큘럼에서 lessonPeriod가 null일 때 발생하던 에러를 수정했습니다.

## 🚩 관련 이슈

## 🙏 여기는 꼭 봐주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 온라인/오프라인 스터디에서 수업 일정을 월/일과 시간 범위로 구성된 두 줄 블록으로 표시.
- 스타일
  - 시작/종료 시간에 자리수 패딩을 적용해 시간 표시 가독성 개선.
- 리팩터
  - 일정 표시 로직을 단일 흐름으로 정리해 일관된 렌더링과 유지보수성 향상.
  - 온라인/오프라인 스터디 유형에서만 일정 시간 범위를 계산·표시하도록 처리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->