### PR TITLE
[Fix] json parsing 문제 해결

### DIFF
--- a/apps/admin/hooks/useParseSearchParams.ts
+++ b/apps/admin/hooks/useParseSearchParams.ts
@@ -9,10 +9,17 @@ const useParseSearchParams = () => {
     const params = new URLSearchParams(query);
     const result: Partial<T> = {};
 
+    const stringKeys = new Set(["discordChannelId", "discordRoleId"]);
+
     params.forEach((value, key) => {
+      if (stringKeys.has(key)) {
+        result[key as keyof T] = value as any;
+        return;
+      }
+
       try {
         result[key as keyof T] = JSON.parse(value);
-      } catch (e) {
+      } catch {
         result[key as keyof T] = value as any;
       }
     });


### PR DESCRIPTION
<!-- 제목: [Feature] PR내용
ex) [Feature] 프로젝트 초기 세팅 -->

## 🎉 변경 사항

  try {
        result[key as keyof T] = JSON.parse(value); -> 제이슨으로 파싱 가능한 경우
      } catch {
        result[key as keyof T] = value as any; -> 제이슨으로 파싱 불가능 해서 따로 key값으로 들어가는 경우
   }
   
   로 되어 있어서 디스코드 ID는 JSON.parse은 숫자로 인식 해버려서  overflow -> 10자리부터 자리 날라감이 일어남
   
   디스코드만 따로
   
   const stringKeys = new Set(["discordChannelId", "discordRoleId"]);
   Set을 정해서
  
  if (stringKeys.has(key)) {
        result[key as keyof T] = value as any;
        return;
      }
  
   면 json이 아닌 따로 저장 하게 만듬



## 🚩 관련 이슈

close #269 

## 🙏 여기는 꼭 봐주세요!

디스코드만 따로 Set으로 지정해서 다른 긴 숫자는 또 파싱 문제가 일어날 가능성이 있어서 
그런 경우가 더 생긴다면 공통적으로 함수를 지정하는 것이 필요함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* Discord 채널 ID 및 역할 ID를 포함한 쿼리 매개변수 처리 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->