### PR TITLE
[Fix] 와우스터디 요소 사이즈 안정화

### DIFF
--- a/apps/admin/app/studies/_components/StudyList.tsx
+++ b/apps/admin/app/studies/_components/StudyList.tsx
@@ -44,6 +44,5 @@ export default StudyList;
 const SectionStyle = css({
   width: "100%",
   height: "100%",
-  overflow: "scroll",
-  scrollbarWidth: "none",
+  overflow: "auto",
 });

--- a/apps/admin/app/studies/_components/StudyListItem.tsx
+++ b/apps/admin/app/studies/_components/StudyListItem.tsx
@@ -45,7 +45,15 @@ const StudyListItem = ({
         </Flex>
       </Table.Left>
       <Table.Right style={TableRightStyle}>
-        <Text typo="body1">
+        <Text
+          typo="body1"
+          style={{
+            minWidth: "50px",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
           {mentorName != null ? `${mentorName} 멘토` : "탈퇴한 회원"}
         </Text>
         <Link
@@ -57,8 +65,13 @@ const StudyListItem = ({
           <WowLinkIcon height={24} stroke="sub" width={24} />
           <TextButton
             aria-label={`${title} 스터디 소개 페이지 열기`}
-            style={{ padding: 0 }}
             text="스터디 소개 페이지"
+            style={{
+              padding: 0,
+              minWidth: "75px",
+              whiteSpace: "normal",
+              wordBreak: "keep-all",
+            }}
           />
         </Link>
         <Flex alignItems="center" gap="sm">
@@ -67,6 +80,7 @@ const StudyListItem = ({
               aria-label="스터디 삭제 확인 페이지로 이동"
               asProp={Link}
               size="sm"
+              style={{ minWidth: "106px", maxHeight: "38px" }}
               variant="outline"
               href={`${routerPath["delete-study-check"].href}/${studyId}?${
                 querySemester ? `semester=${querySemester}&` : ""
@@ -83,6 +97,7 @@ const StudyListItem = ({
             asProp={Link}
             href={`${routerPath.studyDetailInfo.href}${studyId}`}
             size="sm"
+            style={{ minWidth: "119px", maxHeight: "38px" }}
             variant="solid"
           >
             상세 정보 입력
@@ -116,6 +131,7 @@ const TableLeftStyle = {
   flex: 2,
   alignItems: "center",
   gap: "31px",
+  minWidth: "350px",
 };
 
 const TableRightStyle = {

--- a/apps/client/app/(afterLogin)/(pc)/my-study/[studyId]/_components/StudyCurriculum/Curriclum.tsx
+++ b/apps/client/app/(afterLogin)/(pc)/my-study/[studyId]/_components/StudyCurriculum/Curriclum.tsx
@@ -33,17 +33,16 @@ const Curriculum = async ({ studyId }: { studyId: number }) => {
             assignmentHistoryStatus,
             assignmentHistory,
           }) => (
-            <>
+            <div key={session.position}>
               <CurriculumItem
                 assignmentHistory={assignmentHistory}
                 assignmentHistoryStatus={assignmentHistoryStatus}
                 attendanceStatus={attendanceStatus}
-                key={session.position}
                 session={session}
                 studyHistory={studyDashboard.studyHistory}
               />
               <Space height={50} />
-            </>
+            </div>
           )
         )}
       </div>

--- a/apps/client/app/(afterLogin)/(pc)/my-study/[studyId]/_components/StudyCurriculum/Curriclum.tsx
+++ b/apps/client/app/(afterLogin)/(pc)/my-study/[studyId]/_components/StudyCurriculum/Curriclum.tsx
@@ -14,41 +14,48 @@ const Curriculum = async ({ studyId }: { studyId: number }) => {
   }
   return (
     <div className={containerStyle}>
-      <Text as="h2" typo="h2">
-        스터디 커리큘럼
-      </Text>
-      <Space height={10} />
-      <Description />
-      <Space height={50} />
-      <RepositorySubmissionBox
-        repositoryLink={studyDashboard.studyHistory.githubLink}
-        studyId={studyId}
-      />
-      <Space height={50} />
-      {studyDashboard.sessions.map(
-        ({
-          session,
-          attendanceStatus,
-          assignmentHistoryStatus,
-          assignmentHistory,
-        }) => (
-          <>
-            <CurriculumItem
-              assignmentHistory={assignmentHistory}
-              assignmentHistoryStatus={assignmentHistoryStatus}
-              attendanceStatus={attendanceStatus}
-              key={session.position}
-              session={session}
-              studyHistory={studyDashboard.studyHistory}
-            />
-            <Space height={50} />
-          </>
-        )
-      )}
+      <div style={{ minWidth: "950px" }}>
+        <Text as="h2" typo="h2">
+          스터디 커리큘럼
+        </Text>
+        <Space height={10} />
+        <Description />
+        <Space height={50} />
+        <RepositorySubmissionBox
+          repositoryLink={studyDashboard.studyHistory.githubLink}
+          studyId={studyId}
+        />
+        <Space height={50} />
+        {studyDashboard.sessions.map(
+          ({
+            session,
+            attendanceStatus,
+            assignmentHistoryStatus,
+            assignmentHistory,
+          }) => (
+            <>
+              <CurriculumItem
+                assignmentHistory={assignmentHistory}
+                assignmentHistoryStatus={assignmentHistoryStatus}
+                attendanceStatus={attendanceStatus}
+                key={session.position}
+                session={session}
+                studyHistory={studyDashboard.studyHistory}
+              />
+              <Space height={50} />
+            </>
+          )
+        )}
+      </div>
     </div>
   );
 };
 
-const containerStyle = css({ paddingLeft: "1rem" });
+const containerStyle = css({
+  paddingLeft: "1rem",
+  width: "100%",
+  maxWidth: "100%",
+  overflowX: "auto",
+});
 
 export default Curriculum;

--- a/apps/client/app/(afterLogin)/(pc)/my-study/[studyId]/_components/StudyCurriculum/CurriculumItem.tsx
+++ b/apps/client/app/(afterLogin)/(pc)/my-study/[studyId]/_components/StudyCurriculum/CurriculumItem.tsx
@@ -108,7 +108,11 @@ export const CurriculumItem = ({
             <>
               <Flex alignItems="center" justifyContent="space-between">
                 <section id={`assignment-info-${position}`}>
-                  <Flex alignItems="center" gap="xs">
+                  <Flex
+                    alignItems="center"
+                    gap="xs"
+                    style={{ maxWidth: "450px" }}
+                  >
                     <Text>{assignmentTitle}</Text>
                     <Link
                       className={introduceLinkStyle}


### PR DESCRIPTION
<!-- 제목: [Fix] 와우스터디 요소 사이즈 안정화 -->
제목: [Fix] 와우스터디 요소 사이즈 안정화

## 🎉 변경 사항
<img width="889" height="585" alt="image" src="https://github.com/user-attachments/assets/92aa20f8-256b-4fc8-a598-8dc61f595c2d" />
<img width="923" height="523" alt="image" src="https://github.com/user-attachments/assets/332a9ba3-3af4-4ba0-b08c-9206917a6f4d" />


----
<img width="874" height="477" alt="image" src="https://github.com/user-attachments/assets/7252ac4b-7664-4aab-9153-b21c4cef9b23" />

수정 전
<img width="919" height="482" alt="image" src="https://github.com/user-attachments/assets/b25161cc-7641-4759-8925-1aaddc54eec6" />

수정 후

요소들이 동시에 모두 찌그러져서 하나하나 고정 사이즈를 부여하기보다는 스크롤할 수 있는 방향으로 수정하였습니다.

## 🚩 관련 이슈
#273 
## 🙏 여기는 꼭 봐주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style
* 스터디 목록 컨테이너의 스크롤 동작을 `auto`로 변경해 필요 시에만 스크롤바 표시
* 커리큘럼 영역에 최소 너비와 가로 스크롤을 도입해 레이아웃 안정성 강화
* 긴 텍스트에 대한 줄임 처리 스타일을 추가해 표시 가독성 개선
* 버튼 및 입력 요소에 최소/고정 크기 적용으로 시각적 정렬성 향상
* 목록/항목 레이아웃의 간격 및 최대 너비 조정으로 전체 UI 균형 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdg-hongik-univ/wow-class/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->