### PR TITLE
[REFACTOR] 스터디 리스트 정렬

### DIFF
--- a/apps/admin/app/studies/_components/StudyList.tsx
+++ b/apps/admin/app/studies/_components/StudyList.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { css } from "@styled-system/css";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import type { StudyListApiResponseDto } from "types/dtos/studyList";
 
 import EmptyStudyList from "./EmptyStudyList";
@@ -26,24 +26,48 @@ const StudyList = ({
       router.replace("/studies");
   }, [router, semester, semesterList]);
 
+  const SortedStudies = useMemo(() => {
+    if (!studyList) return [];
+
+    const filtered = studyList.filter((studyItem) => {
+      if (semester === null) return true;
+      const currentSemesterString = `${studyItem.study.semester.academicYear}-${
+        studyItem.study.semester.semesterType === "FIRST" ? 1 : 2
+      }`;
+      return semester === currentSemesterString;
+    });
+
+    return filtered.sort((a, b) => {
+      const semesterA = a.study.semester;
+      const semesterB = b.study.semester;
+
+      if (semesterA.academicYear !== semesterB.academicYear) {
+        return semesterB.academicYear - semesterA.academicYear;
+      }
+
+      const weightA = semesterA.semesterType === "SECOND" ? 2 : 1;
+      const weightB = semesterB.semesterType === "SECOND" ? 2 : 1;
+      if (weightA !== weightB) {
+        return weightB - weightA;
+      }
+
+      return a.study.type.localeCompare(b.study.type);
+    });
+  }, [studyList, semester]);
+
   if (studyList?.length === 0) {
     return <EmptyStudyList />;
   }
 
   return (
     <section aria-label="study-list" className={SectionStyle}>
-      {studyList?.map(
-        (studyItem) =>
-          (semester === null ||
-            semester ===
-              `${studyItem.study.semester.academicYear}-${studyItem.study.semester.semesterType === "FIRST" ? 1 : 2}`) && (
-            <StudyListItem
-              adminStatus={adminStatus}
-              key={`${studyItem.study.studyId}`}
-              study={studyItem}
-            />
-          )
-      )}
+      {SortedStudies.map((studyItem) => (
+        <StudyListItem
+          adminStatus={adminStatus}
+          key={`${studyItem.study.studyId}`}
+          study={studyItem}
+        />
+      ))}
     </section>
   );
 };


### PR DESCRIPTION

## 🎉 변경 사항
<img width="783" height="616" alt="image" src="https://github.com/user-attachments/assets/a96dc6f9-ac39-4967-87a6-02debc2caeca" />

스터디 리스트를 최근순으로 정렬했습니다.

스터디들(과제/온라인/오프라인)끼리 정렬도 진행했습니다. 순서는 과제>오프라인>온라인 순입니다.
## 🚩 관련 이슈
closed #275  
## 🙏 여기는 꼭 봐주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **성능 개선**
  * 학습 목록 필터링/정렬 연산을 최적화하여 렌더링 효율 향상

* **개선 사항**
  * `semester` 쿼리 값에 맞는 학습 항목만 표시하도록 개선
  * 학년도(내림차순) → 학기타입 우선(SECOND 우선) → 학습 종류(사전순) 기준으로 정렬
<!-- end of auto-generated comment: release notes by coderabbit.ai -->